### PR TITLE
Update package and library name to SnapSDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,14 +4,14 @@
 import PackageDescription
 
 let package = Package(
-    name: "SnapKit",
+    name: "SnapSDK",
     platforms: [
         .iOS(.v11)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "SnapKit",
+            name: "SnapSDK",
             targets: ["SCSDKCoreKit", "SCSDKLoginKit", "SCSDKCreativeKit"])
     ],
     targets: [


### PR DESCRIPTION
This PR changes the name of the package from SnapKit to SnapSDK to avoid a naming collision with the SnapKit layout framework

Per issue #3 

