### PR TITLE
Expose each framework target as individual product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,13 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "SnapSDK",
-            targets: ["SCSDKCoreKit", "SCSDKLoginKit", "SCSDKCreativeKit"])
+            targets: ["SCSDKCoreKit", "SCSDKLoginKit", "SCSDKCreativeKit"]),
+        .library(
+            name: "SCSDKCoreKit",
+            targets: ["SCSDKCoreKit"]),
+        .library(
+            name: "SCSDKCreativeKit",
+            targets: ["SCSDKCreativeKit"])
     ],
     targets: [
         .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,9 @@ let package = Package(
             name: "SCSDKCoreKit",
             targets: ["SCSDKCoreKit"]),
         .library(
+            name: "SCSDKLoginKit",
+            targets: ["SCSDKLoginKit"]),
+        .library(
             name: "SCSDKCreativeKit",
             targets: ["SCSDKCreativeKit"])
     ],


### PR DESCRIPTION
Apps may not need to consume all of the targets by the package, this allows individual targets to be added as dependencies instead of all of them.
For example:
```
.product(name: "SCSDKCoreKit", package: "snap-kit-spm"),
.product(name: "SCSDKCreativeKit", package: "snap-kit-spm"),
```